### PR TITLE
Add renovate.json config for RenovateBot.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+
+  "labels": ["dependencies"],
+  "commitMessagePrefix": "chore(deps): ",
+  "stabilityDays": 1,
+
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions updates",
+      "schedule": ["* 2 * * *"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker image updates",
+      "schedule": ["* 2 * * *"]
+    },
+    {
+      "matchManagers": ["pip_requirements"],
+      "groupName": "Python dependencies",
+      "schedule": ["* 2 * * *"]
+    }
+  ]
+}


### PR DESCRIPTION
# I have made things!

We initially tried using **Dependabot**, but it didn’t behave reliably for our setup (_it didn’t detect all dependencies correctly and failed to update some files_).
Because of that, we decided to switch to **RenovateBot**, which offers more flexibility and better scheduling options.

**About the renovate.json configuration:**

The `renovate.json` file defines how Renovate should detect, group, and schedule dependency updates.
Here’s what our configuration does:

Manages three ecosystems:

pip_requirements → Python dependencies inside `{{cookiecutter.project_slug}}/pyproject.toml`
dockerfile → Docker base image updates
github-actions → GitHub Actions workflow dependencies

Runs every day at 02:00

The **stabilityDays** setting prevents dependencies from being updated immediately, but forces **RenovateBot** to wait **24 hours** after the release of a new version to avoid unpleasant situations.

I removed pull request limits (prHourlyLimit and prConcurrentLimit set to 0)
so all updates can be created at once without default two-hour wait.

**How to activate RenovateBot on the repository:**

There are two simple options:
Option 1 — Use the GitHub App (recommended)
Option 2 — Run via GitHub Action

I tested using GitHub App, and it worked like a charm.

**So what you need to do:**
1. Merge this PR.
2. Go to https://github.com/apps/renovate to activate **GitHub App**.
3. Click “Install”, choose your account and select only this repository. When choosing a bot mode, you will need to select a mode that allows the bot to open PR's.
4. **RenovateBot** will automatically open a **“Configure Renovate” PR** on the first run. The moment you merge that PR **RenovateBot** will start maintaining dependencies.


## Related issues

Closes #2 