### PR TITLE
Fix template rendering bugs across all cookiecutter choices

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force LF for shell scripts so they run inside Linux containers regardless of host OS.
+*.sh text eol=lf
+*.py text eol=lf
+Dockerfile text eol=lf
+Makefile text eol=lf

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,242 +1,36 @@
 #!/usr/bin/env python3
-"""
-Post-generation hook for cookiecutter template.
-This script automatically generates a .env file based on the cookiecutter context.
+"""Post-generation hook: rename env.template -> .env so the project is ready to run.
+
+The env.template file is fully rendered by cookiecutter (with the chosen
+database/cache/broker variables) — we just give it the conventional name
+applications expect.
 """
 
-import os
+from __future__ import annotations
+
+import shutil
 import sys
 from pathlib import Path
 
 
-def generate_env_file(context):
-    """Generate .env file based on cookiecutter context."""
+def main() -> int:
+    project_dir = Path.cwd()
+    src = project_dir / "env.template"
+    dst = project_dir / ".env"
 
-    project_dir = Path(os.getcwd())
-    env_file = project_dir / ".env"
-
-    # Extract variables from context
-    project_name = context.get("project_name", "").replace(" ", "_").lower()
-    project_description = context.get("project_description", "")
-    author_name = context.get("author_name", "")
-    author_email = context.get("author_email", "")
-    github_username = context.get("github_username", "")
-    domain_name = context.get("domain_name", "")
-    use_broker = context.get("use_broker", "")
-    use_cache = context.get("use_cache", "")
-    use_database = context.get("use_database", "")
-    add_docker = context.get("add_docker", "n")
-
-    # Generate database URL based on selected database
-    if use_database == "postgresql":
-        database_url = f"postgresql://antiques_user:antiques_password@localhost:5432/{project_name}"
-    elif use_database == "mysql":
-        database_url = f"mysql+pymysql://antiques_user:antiques_password@localhost:3306/{project_name}"
-    elif use_database == "sqlite":
-        database_url = f"sqlite:///./{project_name}.db"
-    else:
-        database_url = ""
-
-    # Generate cache URL based on selected cache
-    if use_cache == "redis":
-        cache_url = "redis://localhost:6379/0"
-    elif use_cache == "keydb":
-        cache_url = "redis://localhost:6379/0"
-    elif use_cache == "tarantool":
-        cache_url = "tarantool://localhost:3301"
-    elif use_cache == "dragonfly":
-        cache_url = "redis://localhost:6379/0"
-    else:
-        cache_url = ""
-
-    # Generate broker URL based on selected broker
-    if use_broker == "rabbitmq":
-        broker_url = "amqp://guest:guest@localhost:5672/"
-    elif use_broker == "kafka":
-        broker_url = "kafka://localhost:9092"
-    elif use_broker == "nats":
-        broker_url = "nats://localhost:4222"
-    else:
-        broker_url = ""
-
-    # Generate .env content
-    env_content = f"""# Environment variables for {project_name}
-# Generated automatically by cookiecutter post-gen hook
-
-# Application Settings
-ENVIRONMENT=development
-LOG_LEVEL=INFO
-API_HOST=0.0.0.0
-API_PORT=8000
-API_WORKERS=1
-DEBUG=true
-
-# Database Configuration
-DATABASE_URL="{database_url}"
-
-# Cache Configuration
-"""
-
-    if cache_url:
-        env_content += f'{use_cache.upper()}_URL="{cache_url}"\n'
-
-    # Message Broker Configuration
-    if broker_url:
-        env_content += f'\n# Message Broker Configuration\nBROKER_URL="{broker_url}"\n'
-
-    # Security
-    env_content += f"""
-# Security
-SECRET_KEY="your-secret-key-change-this-in-production"
-ALGORITHM="HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES=30
-
-# CORS Settings
-CORS_ORIGINS=["http://localhost:3000", "http://localhost:8080"]
-
-# Project Info
-PROJECT_NAME="{project_name}"
-PROJECT_DESCRIPTION="{project_description}"
-PROJECT_VERSION="0.1.0"
-AUTHOR_NAME="{author_name}"
-AUTHOR_EMAIL="{author_email}"
-GITHUB_USERNAME="{github_username}"
-DOMAIN_NAME="{domain_name}"
-
-# Docker Settings (if enabled)
-"""
-
-    if add_docker == "y":
-        env_content += """# Docker-specific settings
-DOCKER_HOST=unix:///var/run/docker.sock
-"""
-
-    # Additional settings
-    env_content += """
-# Optional Features
-ENABLE_DOCS=true
-ENABLE_METRICS=false
-ENABLE_TRACING=false
-
-# Email Configuration (optional)
-SMTP_HOST=""
-SMTP_PORT=587
-SMTP_USER=""
-SMTP_PASSWORD=""
-SMTP_FROM=""
-
-# External API Keys (optional)
-EXTERNAL_API_KEY=""
-
-# Monitoring
-SENTRY_DSN=""
-"""
-
-    # Write the .env file
-    try:
-        with open(env_file, 'w', encoding='utf-8') as f:
-            f.write(env_content.strip())
-        print(f"✅ Generated .env file at {env_file}")
-        return True
-    except Exception as e:
-        print(f"❌ Failed to generate .env file: {e}")
-        return False
-
-
-def main():
-    """Main function to run the post-generation hook."""
-
-    # Cookiecutter doesn't automatically pass context to post-gen hooks
-    # We need to read the context from the cookiecutter.json file in the template
-    # or extract it from the generated project's configuration
+    if not src.exists():
+        print(f"[post_gen_project] env.template not found at {src}; nothing to do.")
+        return 0
 
     try:
-        import json
-        print("🔧 Running post-generation hook...")
+        shutil.copyfile(src, dst)
+        print(f"[post_gen_project] Created .env at {dst}")
+    except OSError as exc:
+        print(f"[post_gen_project] Failed to create .env: {exc}", file=sys.stderr)
+        return 1
 
-        # Try to find context in different possible locations
-        context = None
-
-        # Method 1: Look for cookiecutter.json in the parent directory (template root)
-        possible_context_files = [
-            "../cookiecutter.json",  # Template root
-            "cookiecutter.json",     # Current directory
-            "../.cookiecutter.json", # Hidden file in template root
-        ]
-
-        for context_file in possible_context_files:
-            try:
-                with open(context_file, 'r', encoding='utf-8') as f:
-                    template_context = json.load(f)
-                    print(f"📄 Found context in: {context_file}")
-
-                    # Extract the actual values from the template defaults
-                    # Since we're in post-gen, we need to get the actual values used
-                    # We'll use the defaults as fallback and try to get actual values from project
-                    context = {
-                        "project_name": template_context.get("project_name", "my_awesome_api"),
-                        "project_description": template_context.get("project_description", "An awesome API for my project"),
-                        "author_name": template_context.get("author_name", "John Doe"),
-                        "author_email": template_context.get("author_email", "john@example.com"),
-                        "github_username": template_context.get("github_username", "johndoe"),
-                        "domain_name": template_context.get("domain_name", "awesomeapi.com"),
-                        "use_broker": template_context.get("use_broker", "rabbitmq"),
-                        "use_cache": template_context.get("use_cache", "tarantool"),
-                        "use_database": template_context.get("use_database", "mysql"),
-                        "add_docker": template_context.get("add_docker", "y"),
-                        "add_tests": template_context.get("add_tests", "y"),
-                        "add_docs": template_context.get("add_docs", "y"),
-                        "add_precommit": template_context.get("add_precommit", "y"),
-                        "license_type": template_context.get("license_type", "MIT")
-                    }
-                    break
-            except FileNotFoundError:
-                continue
-
-        if not context:
-            print("❌ Could not find cookiecutter context file")
-            # Use default context as fallback
-            context = {
-                "project_name": "my_awesome_api",
-                "project_description": "An awesome API for my project",
-                "author_name": "John Doe",
-                "author_email": "john@example.com",
-                "github_username": "johndoe",
-                "domain_name": "awesomeapi.com",
-                "use_broker": "rabbitmq",
-                "use_cache": "tarantool",
-                "use_database": "mysql",
-                "add_docker": "y",
-                "add_tests": "y",
-                "add_docs": "y",
-                "add_precommit": "y",
-                "license_type": "MIT"
-            }
-            print("📄 Using default context")
-
-        # Try to extract actual project name from current directory
-        current_dir = Path(os.getcwd()).name
-        if current_dir and current_dir != ".":
-            context["project_name"] = current_dir
-            context["project_slug"] = current_dir
-            print(f"📁 Detected project name from directory: {current_dir}")
-
-        # Generate .env file
-        success = generate_env_file(context)
-
-        if success:
-            print("✅ Post-generation hook completed successfully!")
-            sys.exit(0)
-        else:
-            print("❌ Post-generation hook failed!")
-            sys.exit(1)
-
-    except Exception as e:
-        print(f"❌ Unexpected error in post-generation hook: {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Stage 1: Base image with system dependencies
 # =============================================================================
-FROM python:3.14-slim-bookworm AS base
+FROM python:{{ cookiecutter.python_version }}-slim-bookworm AS base
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
@@ -39,7 +39,7 @@ COPY pyproject.toml README.md ./
 # Create virtual environment and install dependencies
 RUN poetry config virtualenvs.create true && \
     poetry config virtualenvs.in-project true && \
-    poetry env use python3.12 && \
+    poetry env use python{{ cookiecutter.python_version }} && \
     poetry install --no-root --only main --no-interaction --no-ansi
 
 # =============================================================================
@@ -77,7 +77,7 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/docs || exit 1
 
 # Default command
-CMD ["poetry", "run", "python", "-m", "{{cookiecutter.project_slug}}/main.py"]
+CMD ["poetry", "run", "uvicorn", "{{cookiecutter.project_slug}}.main:app", "--host", "0.0.0.0", "--port", "8000"]
 
 # =============================================================================
 # Stage 5: Development image
@@ -105,7 +105,7 @@ USER appuser
 EXPOSE 8000
 
 # Default command for development
-CMD ["poetry", "run", "uvicorn", "src.{{cookiecutter.project_slug}}.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["poetry", "run", "uvicorn", "{{cookiecutter.project_slug}}.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
 # =============================================================================
 # Stage 6: Testing image

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -67,46 +67,46 @@ migrate-stamp: ## Stamp database with current migration (without applying)
 
 # Docker commands
 docker-build: ## Build Docker image for production
-	docker build --target production -t antiques:latest .
+	docker build --target production -t {{cookiecutter.project_slug}}:latest .
 
 docker-build-dev: ## Build Docker image for development
-	docker build --target development -t antiques:dev .
+	docker build --target development -t {{cookiecutter.project_slug}}:dev .
 
 docker-build-test: ## Build Docker image for testing
-	docker build --target testing -t antiques:test .
+	docker build --target testing -t {{cookiecutter.project_slug}}:test .
 
 docker-up: ## Start all services with docker-compose
-	docker-compose up -d
+	docker compose up -d
 
 docker-up-dev: ## Start development environment
-	docker-compose --profile dev up -d
+	docker compose --profile dev up -d
 
 docker-down: ## Stop all services
-	docker-compose down
+	docker compose down
 
 docker-logs: ## Show logs for all services
-	docker-compose logs -f
+	docker compose logs -f
 
 docker-logs-app: ## Show logs for application
-	docker-compose logs -f app
+	docker compose logs -f app
 
 docker-shell: ## Open shell in running app container
-	docker-compose exec app bash
+	docker compose exec app bash
 
 docker-migrate: ## Run database migrations
-	docker-compose --profile migrate run --rm migrate
+	docker compose --profile migrate run --rm migrate
 
 docker-test: ## Run tests in Docker
-	docker-compose --profile test run --rm test
+	docker compose --profile test run --rm test
 
 docker-clean: ## Clean up Docker resources
-	docker-compose down -v --remove-orphans
+	docker compose down -v --remove-orphans
 	docker system prune -f
 
 docker-rebuild: ## Rebuild and restart services
-	docker-compose down
-	docker-compose build --no-cache
-	docker-compose up -d
+	docker compose down
+	docker compose build --no-cache
+	docker compose up -d
 
 # Environment setup
 setup-env: ## Create .env file from template
@@ -115,29 +115,61 @@ setup-env: ## Create .env file from template
 # Development helpers
 
 dev-setup-docker: setup-env ## Set up development environment with Docker
-	docker-compose --profile dev up -d postgres redis
+{% if cookiecutter.use_database == "postgresql" and cookiecutter.use_cache == "redis" %}
+	docker compose --profile dev up -d postgres redis
+{% elif cookiecutter.use_database == "postgresql" and cookiecutter.use_cache == "keydb" %}
+	docker compose --profile dev up -d postgres keydb
+{% elif cookiecutter.use_database == "postgresql" and cookiecutter.use_cache == "dragonfly" %}
+	docker compose --profile dev up -d postgres dragonfly
+{% elif cookiecutter.use_database == "postgresql" and cookiecutter.use_cache == "tarantool" %}
+	docker compose --profile dev up -d postgres tarantool
+{% elif cookiecutter.use_database == "postgresql" %}
+	docker compose --profile dev up -d postgres
+{% elif cookiecutter.use_database == "mysql" and cookiecutter.use_cache == "redis" %}
+	docker compose --profile dev up -d mysql redis
+{% elif cookiecutter.use_database == "mysql" %}
+	docker compose --profile dev up -d mysql
+{% elif cookiecutter.use_database == "sqlite" %}
+	docker compose --profile dev --profile init up -d sqlite-init
+{% endif %}
 	@echo "Waiting for services to be ready..."
 	@sleep 10
-	./scripts/init-db.sh
-	make docker-migrate
+{% if cookiecutter.use_database != "none" %}
+	$(MAKE) docker-migrate
+{% endif %}
 	@echo "Development environment is ready!"
 	@echo "Run 'make docker-up-dev' to start the application"
 
 ci: check test ## Run CI pipeline (lint + type check + test)
 	@echo "CI pipeline completed successfully!"
 
+{% if cookiecutter.use_broker == "kafka" %}
 # Kafka commands
 docker-kafka-logs: ## Show Kafka logs
-	docker-compose logs -f kafka
+	docker compose logs -f kafka
 
 docker-kafka-shell: ## Open shell in Kafka container
-	docker-compose exec kafka bash
+	docker compose exec kafka bash
 
 docker-kafka-topics: ## List Kafka topics
-	docker-compose exec kafka kafka-topics --bootstrap-server localhost:9092 --list
+	docker compose exec kafka kafka-topics --bootstrap-server localhost:9092 --list
 
 docker-kafka-create-topic: ## Create Kafka topic for artifacts
-	docker-compose exec kafka kafka-topics --bootstrap-server localhost:9092 --create --topic new_artifacts --partitions 3 --replication-factor 1
+	docker compose exec kafka kafka-topics --bootstrap-server localhost:9092 --create --topic new_artifacts --partitions 3 --replication-factor 1
 
 docker-kafka-consume: ## Consume messages from Kafka topic
-	docker-compose exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic new_artifacts --from-beginning
+	docker compose exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic new_artifacts --from-beginning
+{% endif %}
+{% if cookiecutter.use_broker == "rabbitmq" %}
+# RabbitMQ commands
+docker-rabbitmq-logs: ## Show RabbitMQ logs
+	docker compose logs -f rabbitmq
+
+docker-rabbitmq-shell: ## Open shell in RabbitMQ container
+	docker compose exec rabbitmq bash
+{% endif %}
+{% if cookiecutter.use_broker == "nats" %}
+# NATS commands
+docker-nats-logs: ## Show NATS logs
+	docker compose logs -f nats
+{% endif %}

--- a/{{cookiecutter.project_slug}}/docker-compose.override.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.override.yml
@@ -1,16 +1,26 @@
-version: '3.8'
-
+{% if cookiecutter.use_database in ["postgresql", "mysql"] %}
 services:
   adminer:
     image: adminer:latest
-    container_name: antiques-adminer
+    container_name: {{ cookiecutter.project_slug }}-adminer
     ports:
       - "8080:8080"
     environment:
+{% if cookiecutter.use_database == "postgresql" %}
       ADMINER_DEFAULT_SERVER: postgres
+{% endif %}
+{% if cookiecutter.use_database == "mysql" %}
+      ADMINER_DEFAULT_SERVER: mysql
+{% endif %}
     depends_on:
+{% if cookiecutter.use_database == "postgresql" %}
       - postgres
+{% endif %}
+{% if cookiecutter.use_database == "mysql" %}
+      - mysql
+{% endif %}
     networks:
-      - antiques-network
+      - {{ cookiecutter.project_slug }}-network
     profiles:
       - dev-tools
+{% endif %}

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -1,53 +1,11 @@
-version: '3.8'
-
 # YAML Anchors for common configurations
 x-common-healthcheck: &common-healthcheck
   interval: 10s
   timeout: 5s
   retries: 5
 
-# Network configuration is handled individually per service
-
 x-common-volume: &common-volume
   driver: local
-
-x-app-environment: &app-environment
-  ENVIRONMENT: ${ENVIRONMENT:-production}
-  LOG_LEVEL: ${LOG_LEVEL:-INFO}
-  DEBUG: ${DEBUG:-false}
-  POSTGRES_USER: ${POSTGRES_USER}
-  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-  POSTGRES_SERVER: ${POSTGRES_SERVER}
-  POSTGRES_PORT: ${POSTGRES_PORT}
-  POSTGRES_DB: ${POSTGRES_DB}
-  MUSEUM_API_BASE: ${MUSEUM_API_BASE}
-  CATALOG_API_BASE: ${CATALOG_API_BASE}
-  HTTP_TIMEOUT: ${HTTP_TIMEOUT}
-  BROKER_URL: ${BROKER_URL}
-  BROKER_NEW_ARTIFACT_QUEUE: ${BROKER_NEW_ARTIFACT_QUEUE}
-  PUBLISH_RETRIES: ${PUBLISH_RETRIES}
-  PUBLISH_RETRY_BACKOFF: ${PUBLISH_RETRY_BACKOFF}
-
-x-app-dev-environment: &app-dev-environment
-  ENVIRONMENT: ${ENVIRONMENT:-dev}
-  LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
-  DEBUG: ${DEBUG:-true}
-  POSTGRES_USER: ${POSTGRES_USER}
-  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-  POSTGRES_SERVER: ${POSTGRES_SERVER}
-  POSTGRES_PORT: ${POSTGRES_PORT}
-  POSTGRES_DB: ${POSTGRES_DB}
-  MUSEUM_API_BASE: ${MUSEUM_API_BASE}
-  CATALOG_API_BASE: ${CATALOG_API_BASE}
-  HTTP_TIMEOUT: ${HTTP_TIMEOUT}
-  BROKER_URL: ${BROKER_URL}
-  BROKER_NEW_ARTIFACT_QUEUE: ${BROKER_NEW_ARTIFACT_QUEUE}
-  PUBLISH_RETRIES: ${PUBLISH_RETRIES}
-  PUBLISH_RETRY_BACKOFF: ${PUBLISH_RETRY_BACKOFF}
-
-# Test environment configuration is handled individually per service
-
-# Migration configuration is handled individually per service
 
 services:
 {% if cookiecutter.use_database == "postgresql" %}
@@ -60,7 +18,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
@@ -134,12 +92,22 @@ services:
     container_name: {{ cookiecutter.project_slug }}-sqlite-init
     volumes:
       - sqlite_data:/data
-      - ./scripts/init-sqlite.sh:/init-sqlite.sh:ro
-    command: ["/bin/sh", "/init-sqlite.sh"]
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        mkdir -p /data
+        DB=/data/{{ cookiecutter.database_name }}.db
+        if [ ! -f "$$DB" ]; then
+          echo "Creating SQLite database at $$DB"
+          : > "$$DB"
+          chmod 666 "$$DB"
+        else
+          echo "SQLite database already exists at $$DB"
+        fi
     networks:
       - {{ cookiecutter.project_slug }}-network
-    profiles:
-      - init
 {% endif %}
 
 {% if cookiecutter.use_cache == "redis" %}
@@ -216,34 +184,27 @@ services:
 {% endif %}
 
 {% if cookiecutter.use_broker == "kafka" %}
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.4
-    container_name: {{ cookiecutter.project_slug }}-zookeeper
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    volumes:
-      - zookeeper_data:/var/lib/zookeeper/data
-    networks:
-      - {{ cookiecutter.project_slug }}-network
-
   kafka:
     image: confluentinc/cp-kafka:8.1.0
     container_name: {{ cookiecutter.project_slug }}-kafka
-    depends_on:
-      zookeeper:
-        condition: service_started
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      # KRaft mode (Zookeeper-less, required for cp-kafka 8+)
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_LISTENERS: 'PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:9093'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_NUM_PARTITIONS: 3
       KAFKA_DEFAULT_REPLICATION_FACTOR: 1
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
     ports:
       - "9092:9092"
     volumes:
@@ -252,7 +213,8 @@ services:
       test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
       interval: 30s
       timeout: 10s
-      retries: 5
+      retries: 10
+      start_period: 30s
     networks:
       - {{ cookiecutter.project_slug }}-network
 {% endif %}
@@ -307,8 +269,12 @@ services:
       dockerfile: Dockerfile
       target: production
     container_name: {{ cookiecutter.project_slug }}-app
+    env_file:
+      - .env
     environment:
-      <<: *app-environment
+      ENVIRONMENT: ${ENVIRONMENT:-production}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      DEBUG: ${DEBUG:-false}
     depends_on:
 {% if cookiecutter.use_database == "postgresql" %}
       postgres:
@@ -370,8 +336,12 @@ services:
       dockerfile: Dockerfile
       target: development
     container_name: {{ cookiecutter.project_slug }}-app-dev
+    env_file:
+      - .env
     environment:
-      <<: *app-dev-environment
+      ENVIRONMENT: ${ENVIRONMENT:-dev}
+      LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
+      DEBUG: ${DEBUG:-true}
     depends_on:
 {% if cookiecutter.use_database == "postgresql" %}
       postgres:
@@ -498,22 +468,28 @@ services:
       dockerfile: Dockerfile
       target: testing
     container_name: {{ cookiecutter.project_slug }}-test
+    env_file:
+      - .env
     environment:
       ENVIRONMENT: ${ENVIRONMENT:-testing}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       DEBUG: ${DEBUG:-false}
+{% if cookiecutter.use_database == "postgresql" %}
       POSTGRES_USER: {{ cookiecutter.database_user }}
       POSTGRES_PASSWORD: {{ cookiecutter.database_password }}
       POSTGRES_SERVER: postgres-test
       POSTGRES_PORT: 5432
       POSTGRES_DB: {{ cookiecutter.database_name }}_test
-      MUSEUM_API_BASE: ${MUSEUM_API_BASE}
-      CATALOG_API_BASE: ${CATALOG_API_BASE}
-      HTTP_TIMEOUT: ${HTTP_TIMEOUT}
-      BROKER_URL: ${BROKER_URL}
-      BROKER_NEW_ARTIFACT_QUEUE: ${BROKER_NEW_ARTIFACT_QUEUE}
-      PUBLISH_RETRIES: ${PUBLISH_RETRIES}
-      PUBLISH_RETRY_BACKOFF: ${PUBLISH_RETRY_BACKOFF}
+      DATABASE_URL: postgresql+asyncpg://{{ cookiecutter.database_user }}:{{ cookiecutter.database_password }}@postgres-test:5432/{{ cookiecutter.database_name }}_test
+{% endif %}
+{% if cookiecutter.use_database == "mysql" %}
+      MYSQL_USER: {{ cookiecutter.database_user }}
+      MYSQL_PASSWORD: {{ cookiecutter.database_password }}
+      MYSQL_SERVER: mysql-test
+      MYSQL_PORT: 3306
+      MYSQL_DB: {{ cookiecutter.database_name }}_test
+      DATABASE_URL: mysql+aiomysql://{{ cookiecutter.database_user }}:{{ cookiecutter.database_password }}@mysql-test:3306/{{ cookiecutter.database_name }}_test
+{% endif %}
     depends_on:
 {% if cookiecutter.use_database == "postgresql" %}
       postgres-test:
@@ -586,8 +562,6 @@ volumes:
     <<: *common-volume
 {% endif %}
 {% if cookiecutter.use_broker == "kafka" %}
-  zookeeper_data:
-    <<: *common-volume
   kafka_data:
     <<: *common-volume
 {% endif %}

--- a/{{cookiecutter.project_slug}}/env.template
+++ b/{{cookiecutter.project_slug}}/env.template
@@ -10,12 +10,18 @@ POSTGRES_PASSWORD={{ cookiecutter.database_password }}
 POSTGRES_SERVER=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB={{ cookiecutter.database_name }}
+
+# Database URLs (computed)
+DATABASE_URL=postgresql+asyncpg://{{ cookiecutter.database_user }}:{{ cookiecutter.database_password }}@postgres:5432/{{ cookiecutter.database_name }}
 {% endif %}
 
 {% if cookiecutter.use_database == "sqlite" %}
 # SQLite Configuration
 SQLITE_DB_PATH={{ cookiecutter.database_name }}.db
 SQLITE_DB_DIR=./data
+
+# Database URLs (computed)
+DATABASE_URL=sqlite+aiosqlite:///./data/{{ cookiecutter.database_name }}.db
 {% endif %}
 
 {% if cookiecutter.use_database == "mysql" %}
@@ -25,6 +31,9 @@ MYSQL_PASSWORD={{ cookiecutter.database_password }}
 MYSQL_SERVER=mysql
 MYSQL_PORT=3306
 MYSQL_DB={{ cookiecutter.database_name }}
+
+# Database URLs (computed)
+DATABASE_URL=mysql+aiomysql://{{ cookiecutter.database_user }}:{{ cookiecutter.database_password }}@mysql:3306/{{ cookiecutter.database_name }}
 {% endif %}
 
 # External APIs
@@ -34,7 +43,7 @@ HTTP_TIMEOUT=10.0
 
 {% if cookiecutter.use_broker == "kafka" %}
 # Message Broker (Kafka)
-BROKER_URL=kafka://kafka:9092
+BROKER_URL=kafka:9092
 BROKER_NEW_ARTIFACT_QUEUE=new_artifacts
 
 # Retry Configuration
@@ -70,16 +79,29 @@ REDIS_HOST=redis
 REDIS_DB=0
 REDIS_CACHE_TTL=3600
 REDIS_CACHE_PREFIX={{ cookiecutter.project_slug }}:
+REDIS_URL=redis://:{{ cookiecutter.redis_password }}@redis:6379/0
 {% endif %}
 
 {% if cookiecutter.use_cache == "keydb" %}
-# KeyDB Configuration
-KEYDB_PASSWORD={{ cookiecutter.redis_password }}
-KEYDB_PORT=6379
-KEYDB_HOST=keydb
-KEYDB_DB=0
-KEYDB_CACHE_TTL=3600
-KEYDB_CACHE_PREFIX={{ cookiecutter.project_slug }}:
+# KeyDB Configuration (uses Redis protocol; envvars share REDIS_* prefix)
+REDIS_PASSWORD={{ cookiecutter.redis_password }}
+REDIS_PORT=6379
+REDIS_HOST=keydb
+REDIS_DB=0
+REDIS_CACHE_TTL=3600
+REDIS_CACHE_PREFIX={{ cookiecutter.project_slug }}:
+REDIS_URL=redis://:{{ cookiecutter.redis_password }}@keydb:6379/0
+{% endif %}
+
+{% if cookiecutter.use_cache == "dragonfly" %}
+# Dragonfly Configuration (uses Redis protocol; envvars share REDIS_* prefix)
+REDIS_PASSWORD={{ cookiecutter.redis_password }}
+REDIS_PORT=6379
+REDIS_HOST=dragonfly
+REDIS_DB=0
+REDIS_CACHE_TTL=3600
+REDIS_CACHE_PREFIX={{ cookiecutter.project_slug }}:
+REDIS_URL=redis://:{{ cookiecutter.redis_password }}@dragonfly:6379/0
 {% endif %}
 
 {% if cookiecutter.use_cache == "tarantool" %}
@@ -90,47 +112,7 @@ TARANTOOL_PORT=3301
 TARANTOOL_HOST=tarantool
 TARANTOOL_CACHE_TTL=3600
 TARANTOOL_CACHE_PREFIX={{ cookiecutter.project_slug }}:
-{% endif %}
-
-{% if cookiecutter.use_cache == "dragonfly" %}
-# Dragonfly Configuration
-DRAGONFLY_PASSWORD={{ cookiecutter.redis_password }}
-DRAGONFLY_PORT=6379
-DRAGONFLY_HOST=dragonfly
-DRAGONFLY_DB=0
-DRAGONFLY_CACHE_TTL=3600
-DRAGONFLY_CACHE_PREFIX={{ cookiecutter.project_slug }}:
-{% endif %}
-
-{% if cookiecutter.use_database == "postgresql" %}
-# Database URLs (computed)
-DATABASE_URL=postgresql+asyncpg://{{ cookiecutter.database_user }}:{{ cookiecutter.database_password }}@postgres:5432/{{ cookiecutter.database_name }}
-{% endif %}
-
-{% if cookiecutter.use_database == "sqlite" %}
-# Database URLs (computed)
-DATABASE_URL=sqlite+aiosqlite:///${SQLITE_DB_DIR}/${SQLITE_DB_PATH}
-{% endif %}
-
-{% if cookiecutter.use_database == "mysql" %}
-# Database URLs (computed)
-DATABASE_URL=mysql+aiomysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_SERVER}:${MYSQL_PORT}/${MYSQL_DB}
-{% endif %}
-
-{% if cookiecutter.use_cache == "redis" %}
-REDIS_URL=redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/${REDIS_DB}
-{% endif %}
-
-{% if cookiecutter.use_cache == "keydb" %}
-KEYDB_URL=redis://:${KEYDB_PASSWORD}@${KEYDB_HOST}:${KEYDB_PORT}/${KEYDB_DB}
-{% endif %}
-
-{% if cookiecutter.use_cache == "tarantool" %}
-TARANTOOL_URL=tarantool://${TARANTOOL_USER}:${TARANTOOL_PASSWORD}@${TARANTOOL_HOST}:${TARANTOOL_PORT}
-{% endif %}
-
-{% if cookiecutter.use_cache == "dragonfly" %}
-DRAGONFLY_URL=redis://:${DRAGONFLY_PASSWORD}@${DRAGONFLY_HOST}:${DRAGONFLY_PORT}/${DRAGONFLY_DB}
+TARANTOOL_URL=tarantool://{{ cookiecutter.database_user }}:{{ cookiecutter.database_password }}@tarantool:3301
 {% endif %}
 
 # CORS Configuration

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{ cookiecutter.project_slug }}"
 version = "{{ cookiecutter.version }}"
 description = "{{ cookiecutter.project_description }}"
 readme = "README.md"
-requires-python = ">={{ cookiecutter.python_version }}"
+requires-python = ">={{ cookiecutter.python_version }},<4.0"
 dependencies = [
     "alembic==1.17.1",
 {% if cookiecutter.use_cache == "redis" %}    "redis==7.0.1",{% endif %}

--- a/{{cookiecutter.project_slug}}/scripts/init-db.sql
+++ b/{{cookiecutter.project_slug}}/scripts/init-db.sql
@@ -1,26 +1,15 @@
--- Database initialization script for {{ cookiecutter.project_name }} application
--- This script runs when the PostgreSQL container starts for the first time
+-- Database initialization script for {{ cookiecutter.project_name }}.
+-- The postgres docker image already creates the user/database from
+-- POSTGRES_USER / POSTGRES_DB env vars, so this script only adds
+-- extensions and adjusts privileges idempotently.
 
--- Create the main user
-CREATE USER {{ cookiecutter.database_user }} WITH PASSWORD '{{ cookiecutter.database_password }}';
-
--- Create the database
-CREATE DATABASE {{ cookiecutter.database_name }} OWNER {{ cookiecutter.database_user }};
-
--- Grant privileges
-GRANT ALL PRIVILEGES ON DATABASE {{ cookiecutter.database_name }} TO {{ cookiecutter.database_user }};
-
--- Connect to the {{ cookiecutter.database_name }} database
 \c {{ cookiecutter.database_name }};
 
--- Create extensions
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "pg_trgm";
 
--- Set timezone
 SET timezone = 'UTC';
 
--- Grant schema privileges
 GRANT ALL ON SCHEMA public TO {{ cookiecutter.database_user }};
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ cookiecutter.database_user }};
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {{ cookiecutter.database_user }};

--- a/{{cookiecutter.project_slug}}/scripts/init-sqlite.sh
+++ b/{{cookiecutter.project_slug}}/scripts/init-sqlite.sh
@@ -1,52 +1,17 @@
-#!/bin/bash
-# SQLite initialization script for {{ cookiecutter.project_name }}
-# This script is executed when the SQLite container is first created
-
+#!/bin/sh
+# POSIX sh — works on Alpine without bash.
 set -e
 
-echo "Initializing SQLite database for {{ cookiecutter.project_name }}..."
-
-# Create data directory if it doesn't exist
-mkdir -p /data
-
-# Set database path
 DB_PATH="/data/{{ cookiecutter.database_name }}.db"
 
-# Create SQLite database file if it doesn't exist
+mkdir -p /data
+
 if [ ! -f "$DB_PATH" ]; then
     echo "Creating SQLite database at $DB_PATH"
-    touch "$DB_PATH"
+    : > "$DB_PATH"
     chmod 666 "$DB_PATH"
-    
-    # Create initial tables using sqlite3 command
-    sqlite3 "$DB_PATH" << 'EOF'
--- Enable foreign key support
-PRAGMA foreign_keys = ON;
-
--- Create initial metadata table to track database initialization
-CREATE TABLE IF NOT EXISTS database_metadata (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    key TEXT NOT NULL UNIQUE,
-    value TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
--- Insert initialization record
-INSERT OR IGNORE INTO database_metadata (key, value) VALUES ('initialized', '{{ cookiecutter.project_name }}');
-INSERT OR IGNORE INTO database_metadata (key, value) VALUES ('version', '1.0.0');
-INSERT OR IGNORE INTO database_metadata (key, value) VALUES ('created_at', datetime('now'));
-
--- Show database info
-SELECT 'Database initialized successfully' as status;
-SELECT datetime('now') as initialization_time;
-EOF
-    
-    echo "SQLite database initialized successfully"
 else
     echo "SQLite database already exists at $DB_PATH"
 fi
 
-# Set proper permissions
-chmod 666 "$DB_PATH"
-
-echo "SQLite initialization completed"
+echo "SQLite init complete"

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config/database.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config/database.py
@@ -1,54 +1,43 @@
-from typing import cast, final
+from typing import final
 
-from pydantic import Field, PostgresDsn, computed_field
+from pydantic import Field, computed_field
 from pydantic_settings import BaseSettings
 
 
 @final
 class DatabaseSettings(BaseSettings):
-    """
-    Database configuration settings.
+    """Database configuration.
 
-    Attributes:
-        postgres_user (str): PostgreSQL username.
-        postgres_password (str): PostgreSQL password.
-        postgres_server (str): PostgreSQL server host.
-        postgres_port (int): PostgreSQL server port.
-        postgres_db (str): PostgreSQL database name.
+    Reads the full SQLAlchemy URL from DATABASE_URL so the same code works
+    across PostgreSQL, MySQL, and SQLite. Engine-specific fields are kept
+    as optional fallbacks for code that references them directly.
     """
 
-    postgres_user: str = Field(..., alias="POSTGRES_USER")
-    postgres_password: str = Field(..., alias="POSTGRES_PASSWORD")
-    postgres_server: str = Field(..., alias="POSTGRES_SERVER")
+    database_url: str = Field("", alias="DATABASE_URL")
+
+    # PostgreSQL fields (kept always for backwards-compat with Settings facade).
+    postgres_user: str = Field("", alias="POSTGRES_USER")
+    postgres_password: str = Field("", alias="POSTGRES_PASSWORD")
+    postgres_server: str = Field("", alias="POSTGRES_SERVER")
     postgres_port: int = Field(5432, alias="POSTGRES_PORT")
-    postgres_db: str = Field(..., alias="POSTGRES_DB")
+    postgres_db: str = Field("", alias="POSTGRES_DB")
+
+{% if cookiecutter.use_database == "mysql" %}
+    mysql_user: str = Field("", alias="MYSQL_USER")
+    mysql_password: str = Field("", alias="MYSQL_PASSWORD")
+    mysql_server: str = Field("", alias="MYSQL_SERVER")
+    mysql_port: int = Field(3306, alias="MYSQL_PORT")
+    mysql_db: str = Field("", alias="MYSQL_DB")
+{% endif %}
+
+{% if cookiecutter.use_database == "sqlite" %}
+    sqlite_db_path: str = Field("app.db", alias="SQLITE_DB_PATH")
+    sqlite_db_dir: str = Field("./data", alias="SQLITE_DB_DIR")
+{% endif %}
 
     @computed_field
-    def database_url(self) -> PostgresDsn:
-        """
-        Constructs the PostgreSQL database URL.
-
-        Returns:
-            PostgresDsn: The constructed database URL.
-        """
-        return PostgresDsn.build(
-            scheme="postgresql+asyncpg",
-            username=self.postgres_user,
-            password=self.postgres_password,
-            host=self.postgres_server,
-            port=self.postgres_port,
-            path=self.postgres_db,
-        )
-
-    @computed_field
-    def sqlalchemy_database_uri(self) -> PostgresDsn:
-        """
-        Returns the SQLAlchemy compatible database URI.
-
-        Returns:
-            PostgresDsn: The SQLAlchemy database URI.
-        """
-        return cast("PostgresDsn", self.database_url)
+    def sqlalchemy_database_uri(self) -> str:
+        return self.database_url
 
     class Config:
         env_file = ".env"

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config/ioc/di.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config/ioc/di.py
@@ -1,7 +1,9 @@
 from dishka import Provider
 
 from {{cookiecutter.project_slug}}.config.ioc.providers import (
+{% if cookiecutter.use_broker != "none" %}
     BrokerProvider,
+{% endif %}
     CacheProvider,
     DatabaseProvider,
     HTTPClientProvider,
@@ -15,17 +17,14 @@ from {{cookiecutter.project_slug}}.config.ioc.providers import (
 
 
 def get_providers() -> list[Provider]:
-    """
-    Returns a list of Dishka providers for dependency injection.
-
-    Returns:
-        list[Provider]: A list of configured providers.
-    """
+    """Returns the list of Dishka providers for dependency injection."""
     return [
         SettingsProvider(),
         DatabaseProvider(),
         HTTPClientProvider(),
+{% if cookiecutter.use_broker != "none" %}
         BrokerProvider(),
+{% endif %}
         RepositoryProvider(),
         ServiceProvider(),
         MapperProvider(),

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config/ioc/providers.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config/ioc/providers.py
@@ -1,13 +1,23 @@
 from collections.abc import AsyncIterator
 
 from dishka import Provider, Scope, provide
-from faststream.kafka import KafkaBroker
 from httpx import AsyncClient
-import redis.asyncio as redis
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
 )
+
+{% if cookiecutter.use_broker == "kafka" %}
+from faststream.kafka import KafkaBroker as _BrokerType
+{% elif cookiecutter.use_broker == "rabbitmq" %}
+from faststream.rabbit import RabbitBroker as _BrokerType
+{% elif cookiecutter.use_broker == "nats" %}
+from faststream.nats import NatsBroker as _BrokerType
+{% endif %}
+
+{% if cookiecutter.use_cache in ["redis", "keydb", "dragonfly"] %}
+import redis.asyncio as redis
+{% endif %}
 
 from {{cookiecutter.project_slug}}.application.interfaces.cache import CacheProtocol
 from {{cookiecutter.project_slug}}.application.interfaces.http_clients import (
@@ -43,8 +53,8 @@ from {{cookiecutter.project_slug}}.application.use_cases.save_artifact_to_repo i
     SaveArtifactToRepoUseCase,
 )
 from {{cookiecutter.project_slug}}.config.base import Settings
-from {{cookiecutter.project_slug}}.infrastructures.broker.publisher import KafkaPublisher
-from {{cookiecutter.project_slug}}.infrastructures.cache.redis_client import RedisCacheClient
+from {{cookiecutter.project_slug}}.infrastructures.broker.publisher import MessageBrokerPublisher
+from {{cookiecutter.project_slug}}.infrastructures.cache.redis_client import CacheClient
 from {{cookiecutter.project_slug}}.infrastructures.db.mappers.artifact_db_mapper import ArtifactDBMapper
 from {{cookiecutter.project_slug}}.infrastructures.db.repositories.artifact import ArtifactRepositorySQLAlchemy
 from {{cookiecutter.project_slug}}.infrastructures.db.session import create_engine, get_session_factory
@@ -58,30 +68,20 @@ from {{cookiecutter.project_slug}}.presentation.api.rest.v1.mappers.artifact_map
 
 
 class SettingsProvider(Provider):
-    """
-    Provides application settings.
-    """
+    """Provides application settings."""
 
     @provide(scope=Scope.APP)
     def get_settings(self) -> Settings:
-        """
-        Provides the Settings instance.
-        """
         return Settings()
 
 
 class DatabaseProvider(Provider):
-    """
-    Provides database-related dependencies, such as session factory and sessions.
-    """
+    """Provides database session factory and per-request sessions."""
 
     @provide(scope=Scope.APP)
     async def get_session_factory(
         self, settings: Settings
     ) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
-        """
-        Provides an asynchronous session factory for SQLAlchemy.
-        """
         engine = create_engine(str(settings.database_url), is_echo=settings.debug)
         session_factory = get_session_factory(engine)
         try:
@@ -93,23 +93,15 @@ class DatabaseProvider(Provider):
     async def get_session(
         self, factory: async_sessionmaker[AsyncSession]
     ) -> AsyncIterator[AsyncSession]:
-        """
-        Provides an asynchronous SQLAlchemy session.
-        """
         async with factory() as session:
             yield session
 
 
 class HTTPClientProvider(Provider):
-    """
-    Provides an asynchronous HTTP client.
-    """
+    """Provides an asynchronous HTTP client."""
 
     @provide(scope=Scope.APP)
     async def get_http_client(self, settings: Settings) -> AsyncIterator[AsyncClient]:
-        """
-        Provides an AsyncClient instance with configured timeout.
-        """
         client = AsyncClient(timeout=settings.http_timeout)
         try:
             yield client
@@ -117,42 +109,32 @@ class HTTPClientProvider(Provider):
             await client.aclose()
 
 
+{% if cookiecutter.use_broker != "none" %}
 class BrokerProvider(Provider):
-    """
-    Provides a Kafka message broker instance.
-    """
+    """Provides the message broker connection."""
 
     @provide(scope=Scope.APP)
-    async def get_broker(self, settings: Settings) -> AsyncIterator[KafkaBroker]:
-        """
-        Provides a KafkaBroker instance.
-        """
-        broker = KafkaBroker(settings.broker_url)
+    async def get_broker(self, settings: Settings) -> AsyncIterator[_BrokerType]:
+        broker = _BrokerType(settings.broker_url)
         try:
             yield broker
         finally:
             await broker.stop()
+{% endif %}
 
 
 class RepositoryProvider(Provider):
-    """
-    Provides repository implementations.
-    """
+    """Provides repository implementations."""
 
     @provide(scope=Scope.REQUEST)
     def get_artifact_repository(
         self, session: AsyncSession, db_mapper: ArtifactDBMapper
     ) -> ArtifactRepositoryProtocol:
-        """
-        Provides an ArtifactRepositoryProtocol implementation.
-        """
         return ArtifactRepositorySQLAlchemy(session=session, mapper=db_mapper)
 
 
 class UnitOfWorkProvider(Provider):
-    """
-    Provides Unit of Work implementations.
-    """
+    """Provides Unit of Work implementations."""
 
     @provide(scope=Scope.REQUEST)
     def get_unit_of_work(
@@ -160,16 +142,11 @@ class UnitOfWorkProvider(Provider):
         session: AsyncSession,
         repository: ArtifactRepositoryProtocol,
     ) -> UnitOfWorkProtocol:
-        """
-        Provides a UnitOfWorkProtocol implementation.
-        """
         return UnitOfWorkSQLAlchemy(session=session, repository=repository)
 
 
 class ServiceProvider(Provider):
-    """
-    Provides service clients for external integrations.
-    """
+    """Provides service clients for external integrations."""
 
     @provide(scope=Scope.REQUEST)
     def get_external_museum_api_client(
@@ -178,9 +155,6 @@ class ServiceProvider(Provider):
         settings: Settings,
         infrastructure_mapper: SerializationMapperProtocol,
     ) -> ExternalMuseumAPIProtocol:
-        """
-        Provides an ExternalMuseumAPIProtocol implementation.
-        """
         return ExternalMuseumAPIClient(
             base_url=settings.museum_api_base,
             client=client,
@@ -194,77 +168,59 @@ class ServiceProvider(Provider):
         settings: Settings,
         infrastructure_mapper: SerializationMapperProtocol,
     ) -> PublicCatalogAPIProtocol:
-        """
-        Provides a PublicCatalogAPIProtocol implementation.
-        """
         return PublicCatalogAPIClient(
             base_url=settings.catalog_api_base_url,
             client=client,
             mapper=infrastructure_mapper,
         )
 
+{% if cookiecutter.use_broker != "none" %}
     @provide(scope=Scope.REQUEST)
     def get_message_broker(
         self,
-        broker: KafkaBroker,
+        broker: _BrokerType,
         infrastructure_mapper: SerializationMapperProtocol,
     ) -> MessageBrokerPublisherProtocol:
-        """
-        Provides a MessageBrokerPublisherProtocol implementation.
-        """
-        return KafkaPublisher(
+        return MessageBrokerPublisher(
             broker=broker,
             mapper=infrastructure_mapper,
         )
+{% else %}
+    @provide(scope=Scope.REQUEST)
+    def get_message_broker(self) -> MessageBrokerPublisherProtocol:
+        return MessageBrokerPublisher()
+{% endif %}
 
 
 class MapperProvider(Provider):
-    """
-    Provides various mapper implementations for different layers.
-    """
+    """Provides various mapper implementations for different layers."""
 
     @provide(scope=Scope.APP)
     def get_artifact_mapper(self) -> DtoEntityMapperProtocol:
-        """
-        Provides the Application layer mapper (Domain Entity <-> Application DTO).
-        """
         return ArtifactMapper()
 
     @provide(scope=Scope.REQUEST)
     def get_db_mapper(self) -> ArtifactDBMapper:
-        """
-        Provides the Database mapper (Domain Entity <-> SQLAlchemy Model).
-        """
         return ArtifactDBMapper()
 
     @provide(scope=Scope.REQUEST)
     def get_infrastructure_artifact_mapper(self) -> SerializationMapperProtocol:
-        """
-        Provides the Infrastructure mapper (Application DTO <-> Pydantic/JSON).
-        """
         return InfrastructureArtifactMapper()
 
     @provide(scope=Scope.REQUEST)
     def get_presentation_artifact_mapper(self) -> ArtifactPresentationMapper:
-        """
-        Provides the Presentation mapper (Application DTO -> Response Schema).
-        """
         return ArtifactPresentationMapper()
 
 
 class CacheProvider(Provider):
-    """
-    Provides caching services using Redis.
-    """
+    """Provides the cache client."""
 
     @provide(scope=Scope.APP)
     async def get_cache_service(
         self, settings: Settings
     ) -> AsyncIterator[CacheProtocol]:
-        """
-        Provides a CacheProtocol implementation.
-        """
-        redis_client = await redis.from_url(
+{% if cookiecutter.use_cache in ["redis", "keydb", "dragonfly"] %}
+        redis_client = redis.from_url(
             str(settings.redis_url),
             encoding="utf-8",
             decode_responses=True,
@@ -274,19 +230,24 @@ class CacheProvider(Provider):
             socket_connect_timeout=5,
             socket_timeout=5,
         )
-        cache_service = RedisCacheClient(
+        cache_service = CacheClient(
             client=redis_client, ttl=settings.redis_cache_ttl
         )
         try:
             yield cache_service
         finally:
             await cache_service.close()
+{% else %}
+        cache_service = CacheClient()
+        try:
+            yield cache_service
+        finally:
+            await cache_service.close()
+{% endif %}
 
 
 class UseCaseProvider(Provider):
-    """
-    Provides application use cases.
-    """
+    """Provides application use cases."""
 
     @provide(scope=Scope.REQUEST)
     def get_get_artifact_from_cache_use_case(
@@ -294,9 +255,6 @@ class UseCaseProvider(Provider):
         cache_client: CacheProtocol,
         serialization_mapper: SerializationMapperProtocol,
     ) -> GetArtifactFromCacheUseCase:
-        """
-        Provides a GetArtifactFromCacheUseCase instance.
-        """
         return GetArtifactFromCacheUseCase(
             cache_client=cache_client, serialization_mapper=serialization_mapper
         )
@@ -305,9 +263,6 @@ class UseCaseProvider(Provider):
     def get_get_artifact_from_repo_use_case(
         self, uow: UnitOfWorkProtocol, artifact_mapper: DtoEntityMapperProtocol
     ) -> GetArtifactFromRepoUseCase:
-        """
-        Provides a GetArtifactFromRepoUseCase instance.
-        """
         return GetArtifactFromRepoUseCase(uow=uow, artifact_mapper=artifact_mapper)
 
     @provide(scope=Scope.REQUEST)
@@ -315,18 +270,12 @@ class UseCaseProvider(Provider):
         self,
         museum_api_client: ExternalMuseumAPIProtocol,
     ) -> FetchArtifactFromMuseumAPIUseCase:
-        """
-        Provides a FetchArtifactFromMuseumAPIUseCase instance.
-        """
         return FetchArtifactFromMuseumAPIUseCase(museum_api_client=museum_api_client)
 
     @provide(scope=Scope.REQUEST)
     def get_save_artifact_to_repo_use_case(
         self, uow: UnitOfWorkProtocol, artifact_mapper: DtoEntityMapperProtocol
     ) -> SaveArtifactToRepoUseCase:
-        """
-        Provides a SaveArtifactToRepoUseCase instance.
-        """
         return SaveArtifactToRepoUseCase(uow=uow, artifact_mapper=artifact_mapper)
 
     @provide(scope=Scope.REQUEST)
@@ -335,9 +284,6 @@ class UseCaseProvider(Provider):
         cache_client: CacheProtocol,
         serialization_mapper: SerializationMapperProtocol,
     ) -> SaveArtifactToCacheUseCase:
-        """
-        Provides a SaveArtifactToCacheUseCase instance.
-        """
         return SaveArtifactToCacheUseCase(
             cache_client=cache_client, serialization_mapper=serialization_mapper
         )
@@ -348,9 +294,6 @@ class UseCaseProvider(Provider):
         message_broker: MessageBrokerPublisherProtocol,
         artifact_mapper: DtoEntityMapperProtocol,
     ) -> PublishArtifactToBrokerUseCase:
-        """
-        Provides a PublishArtifactToBrokerUseCase instance.
-        """
         return PublishArtifactToBrokerUseCase(
             message_broker=message_broker, artifact_mapper=artifact_mapper
         )
@@ -361,9 +304,6 @@ class UseCaseProvider(Provider):
         catalog_api_client: PublicCatalogAPIProtocol,
         artifact_mapper: DtoEntityMapperProtocol,
     ) -> PublishArtifactToCatalogUseCase:
-        """
-        Provides a PublishArtifactToCatalogUseCase instance.
-        """
         return PublishArtifactToCatalogUseCase(
             catalog_api_client=catalog_api_client, artifact_mapper=artifact_mapper
         )
@@ -379,9 +319,6 @@ class UseCaseProvider(Provider):
         publish_artifact_to_broker_use_case: PublishArtifactToBrokerUseCase,
         publish_artifact_to_catalog_use_case: PublishArtifactToCatalogUseCase,
     ) -> ProcessArtifactUseCase:
-        """
-        Provides a ProcessArtifactUseCase instance.
-        """
         return ProcessArtifactUseCase(
             get_artifact_from_cache_use_case=get_artifact_from_cache_use_case,
             get_artifact_from_repo_use_case=get_artifact_from_repo_use_case,

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config/redis.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config/redis.py
@@ -27,7 +27,7 @@ class RedisSettings(BaseSettings):
     redis_host: str = Field("redis", alias="REDIS_HOST")
     redis_db: int = Field(0, alias="REDIS_DB")
     redis_cache_ttl: int = Field(3600, alias="REDIS_CACHE_TTL")  # 1 hour default TTL
-    redis_cache_prefix: str = Field("antiques:", alias="REDIS_CACHE_PREFIX")
+    redis_cache_prefix: str = Field("{{ cookiecutter.project_slug }}:", alias="REDIS_CACHE_PREFIX")
 
     class Config:
         env_file = ".env"

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/infrastructures/broker/publisher.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/infrastructures/broker/publisher.py
@@ -1,3 +1,4 @@
+{% if cookiecutter.use_broker == "kafka" %}
 from dataclasses import dataclass, field
 import json
 from typing import final
@@ -12,36 +13,115 @@ from {{cookiecutter.project_slug}}.infrastructures.mappers.artifact import Infra
 
 @final
 @dataclass(frozen=True, slots=True, kw_only=True)
-class KafkaPublisher(MessageBrokerPublisherProtocol):
-    """
-    Kafka implementation of the MessageBrokerPublisherProtocol.
-    Publishes artifact admission notifications to a Kafka topic.
-    """
+class MessageBrokerPublisher(MessageBrokerPublisherProtocol):
+    """Kafka implementation of MessageBrokerPublisherProtocol."""
 
     broker: KafkaBroker
-    topic: str = field(default="new_artifacts")
     mapper: InfrastructureArtifactMapper
+    topic: str = field(default="new_artifacts")
 
     async def publish_new_artifact(
         self, artifact: ArtifactAdmissionNotificationDTO
     ) -> None:
-        """
-        Publishes a new artifact admission notification to Kafka.
-
-        Args:
-            artifact: The ArtifactAdmissionNotificationDTO to publish.
-
-        Raises:
-            Exception: If publishing the message fails.
-        """
         try:
             artifact_dict = self.mapper.to_admission_notification_dict(artifact)
             await self.broker.publish(
-                key=artifact_dict["inventory_id"],
-                message=json.dumps(artifact_dict, ensure_ascii=False),
+                json.dumps(artifact_dict, ensure_ascii=False),
                 topic=self.topic,
+                key=artifact_dict["inventory_id"].encode(),
             )
         except Exception as e:
             logger = structlog.get_logger(__name__)
             logger.error("Failed to publish artifact", error=str(e))
             raise
+{% elif cookiecutter.use_broker == "rabbitmq" %}
+from dataclasses import dataclass, field
+import json
+from typing import final
+
+import structlog
+from faststream.rabbit import RabbitBroker
+
+from {{cookiecutter.project_slug}}.application.dtos.artifact import ArtifactAdmissionNotificationDTO
+from {{cookiecutter.project_slug}}.application.interfaces.message_broker import MessageBrokerPublisherProtocol
+from {{cookiecutter.project_slug}}.infrastructures.mappers.artifact import InfrastructureArtifactMapper
+
+
+@final
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MessageBrokerPublisher(MessageBrokerPublisherProtocol):
+    """RabbitMQ implementation of MessageBrokerPublisherProtocol."""
+
+    broker: RabbitBroker
+    mapper: InfrastructureArtifactMapper
+    queue: str = field(default="new_artifacts")
+
+    async def publish_new_artifact(
+        self, artifact: ArtifactAdmissionNotificationDTO
+    ) -> None:
+        try:
+            artifact_dict = self.mapper.to_admission_notification_dict(artifact)
+            await self.broker.publish(
+                json.dumps(artifact_dict, ensure_ascii=False),
+                queue=self.queue,
+            )
+        except Exception as e:
+            logger = structlog.get_logger(__name__)
+            logger.error("Failed to publish artifact", error=str(e))
+            raise
+{% elif cookiecutter.use_broker == "nats" %}
+from dataclasses import dataclass, field
+import json
+from typing import final
+
+import structlog
+from faststream.nats import NatsBroker
+
+from {{cookiecutter.project_slug}}.application.dtos.artifact import ArtifactAdmissionNotificationDTO
+from {{cookiecutter.project_slug}}.application.interfaces.message_broker import MessageBrokerPublisherProtocol
+from {{cookiecutter.project_slug}}.infrastructures.mappers.artifact import InfrastructureArtifactMapper
+
+
+@final
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MessageBrokerPublisher(MessageBrokerPublisherProtocol):
+    """NATS implementation of MessageBrokerPublisherProtocol."""
+
+    broker: NatsBroker
+    mapper: InfrastructureArtifactMapper
+    subject: str = field(default="new_artifacts")
+
+    async def publish_new_artifact(
+        self, artifact: ArtifactAdmissionNotificationDTO
+    ) -> None:
+        try:
+            artifact_dict = self.mapper.to_admission_notification_dict(artifact)
+            await self.broker.publish(
+                json.dumps(artifact_dict, ensure_ascii=False),
+                subject=self.subject,
+            )
+        except Exception as e:
+            logger = structlog.get_logger(__name__)
+            logger.error("Failed to publish artifact", error=str(e))
+            raise
+{% else %}
+from dataclasses import dataclass
+from typing import final
+
+import structlog
+
+from {{cookiecutter.project_slug}}.application.dtos.artifact import ArtifactAdmissionNotificationDTO
+from {{cookiecutter.project_slug}}.application.interfaces.message_broker import MessageBrokerPublisherProtocol
+
+
+@final
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MessageBrokerPublisher(MessageBrokerPublisherProtocol):
+    """No-op publisher (used when no message broker is configured)."""
+
+    async def publish_new_artifact(
+        self, artifact: ArtifactAdmissionNotificationDTO
+    ) -> None:
+        logger = structlog.get_logger(__name__)
+        logger.debug("No broker configured; skipping publish_new_artifact")
+{% endif %}

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/infrastructures/cache/redis_client.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/infrastructures/cache/redis_client.py
@@ -1,3 +1,4 @@
+{% if cookiecutter.use_cache in ["redis", "keydb", "dragonfly"] %}
 from dataclasses import dataclass
 import json
 from typing import Any, final
@@ -13,147 +14,110 @@ logger = structlog.get_logger(__name__)
 
 @final
 @dataclass(frozen=True, slots=True, kw_only=True)
-class RedisCacheClient(CacheProtocol):
-    """
-    Redis implementation of the CacheProtocol for caching operations.
-    """
+class CacheClient(CacheProtocol):
+    """Redis-protocol cache client (supports Redis, KeyDB, Dragonfly)."""
+
     client: Redis
     ttl: int | None = None
 
     async def get(self, key: str) -> dict[str, Any] | None:
-        """
-        Retrieves a value from Redis cache by key.
-
-        Args:
-            key: Cache key to retrieve.
-
-        Returns:
-            Cached dictionary data or None if not found or an error occurs.
-        """
         try:
             value = await self.client.get(key)
             if value is None:
                 return None
             return json.loads(value)
         except (ConnectionError, redis.exceptions.RedisError) as e:
-            logger.error(
-                "Redis get operation failed", key=key, error=str(e)
-            )
+            logger.error("Cache get failed", key=key, error=str(e))
             return None
         except (json.JSONDecodeError, TypeError) as e:
-            logger.warning(
-                "Failed to decode cached value", key=key, error=str(e)
-            )
+            logger.warning("Failed to decode cached value", key=key, error=str(e))
             return None
 
     async def set(self, key: str, value: dict[str, Any], ttl: int | None = None) -> bool:
-        """
-        Stores a value in Redis cache with an optional TTL.
-
-        Args:
-            key: Cache key to store under.
-            value: Dictionary data to cache.
-            ttl: Time-to-live in seconds (None for default or no expiration).
-
-        Returns:
-            True if successful, False otherwise.
-        """
         try:
-            serialized_value = json.dumps(value, default=str)
-            if ttl is not None:
-                await self.client.setex(key, ttl, serialized_value)
-            elif self.ttl is not None:
-                await self.client.setex(key, self.ttl, serialized_value)
+            serialized = json.dumps(value, default=str)
+            effective_ttl = ttl if ttl is not None else self.ttl
+            if effective_ttl is not None:
+                await self.client.setex(key, effective_ttl, serialized)
             else:
-                await self.client.set(key, serialized_value)
+                await self.client.set(key, serialized)
             return True
         except (ConnectionError, redis.exceptions.RedisError) as e:
-            logger.error(
-                "Redis set operation failed", key=key, error=str(e)
-            )
+            logger.error("Cache set failed", key=key, error=str(e))
             return False
         except (TypeError, ValueError) as e:
-            logger.error(
-                "Failed to serialize value for cache",
-                key=key,
-                error=str(e),
-            )
+            logger.error("Failed to serialize value for cache", key=key, error=str(e))
             return False
 
     async def delete(self, key: str) -> bool:
-        """
-        Deletes a value from Redis cache.
-
-        Args:
-            key: Cache key to delete.
-
-        Returns:
-            True if key was deleted, False if key didn't exist or an error occurs.
-        """
         try:
-            result = await self.client.delete(key)
-            return result > 0
+            return await self.client.delete(key) > 0
         except (ConnectionError, redis.exceptions.RedisError) as e:
-            logger.error(
-                "Redis delete operation failed", key=key, error=str(e)
-            )
+            logger.error("Cache delete failed", key=key, error=str(e))
             return False
 
     async def exists(self, key: str) -> bool:
-        """
-        Checks if a key exists in Redis cache.
-
-        Args:
-            key: Cache key to check.
-
-        Returns:
-            True if key exists, False otherwise or if an error occurs.
-        """
         try:
             return bool(await self.client.exists(key))
         except (ConnectionError, redis.exceptions.RedisError) as e:
-            logger.error(
-                "Redis exists operation failed", key=key, error=str(e)
-            )
+            logger.error("Cache exists failed", key=key, error=str(e))
             return False
 
     async def clear(self, pattern: str) -> int:
-        """
-        Clears cache entries matching a pattern in Redis.
-
-        Args:
-            pattern: Pattern to match keys (e.g., 'user:*').
-
-        Returns:
-            Number of keys deleted.
-        """
         try:
-            keys = []
-            async for key in self.client.scan_iter(match=pattern):
-                keys.append(key)
-            if keys:
-                deleted_count = await self.client.delete(*keys)
-                logger.info(
-                    "Cleared cache keys matching pattern",
-                    pattern=pattern,
-                    count=deleted_count,
-                )
-                return deleted_count
-            return 0
+            keys = [key async for key in self.client.scan_iter(match=pattern)]
+            if not keys:
+                return 0
+            deleted = await self.client.delete(*keys)
+            logger.info("Cleared cache keys", pattern=pattern, count=deleted)
+            return deleted
         except (ConnectionError, redis.exceptions.RedisError) as e:
-            logger.error(
-                "Redis clear pattern operation failed",
-                pattern=pattern,
-                error=str(e),
-            )
+            logger.error("Cache clear failed", pattern=pattern, error=str(e))
             return 0
 
     async def close(self) -> None:
-        """
-        Closes the Redis client connection.
-        """
         try:
-            await self.client.close()
-            logger.info("Redis connection closed")
+            await self.client.aclose()
         except (ConnectionError, redis.exceptions.RedisError) as e:
-            logger.error("Failed to close Redis connection", error=str(e))
+            logger.error("Failed to close cache connection", error=str(e))
+
+
+# Backwards-compatible alias.
+RedisCacheClient = CacheClient
+{% else %}
+from dataclasses import dataclass
+from typing import Any, final
+
+import structlog
+
+from {{cookiecutter.project_slug}}.application.interfaces.cache import CacheProtocol
+
+logger = structlog.get_logger(__name__)
+
+
+@final
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CacheClient(CacheProtocol):
+    """No-op cache client (used when no cache backend is configured{% if cookiecutter.use_cache == "tarantool" %}, or for Tarantool which is not yet implemented{% endif %})."""
+
+    async def get(self, key: str) -> dict[str, Any] | None:
+        return None
+
+    async def set(self, key: str, value: dict[str, Any], ttl: int | None = None) -> bool:
+        return True
+
+    async def delete(self, key: str) -> bool:
+        return True
+
+    async def exists(self, key: str) -> bool:
+        return False
+
+    async def clear(self, pattern: str) -> int:
+        return 0
+
+    async def close(self) -> None:
+        pass
+
+
+RedisCacheClient = CacheClient
+{% endif %}


### PR DESCRIPTION
Universal bugs (affected every generated project):
- Dockerfile: base image was python:3.14-slim-bookworm which does not exist -> template now uses python:{{cookiecutter.python_version}}.
- Dockerfile: production CMD had a broken `-m kufar_notifier_bot/main.py` and development CMD prefixed the package with `src.` -> both rewritten to `uvicorn {{cookiecutter.project_slug}}.main:app`.
- pyproject.toml: requires-python had no upper bound which Poetry could not resolve against aio-pika (faststream[rabbit] dependency) -> now ">={{python_version}},<4.0".
- docker-compose.override.yml: hardcoded `antiques-network` and `antiques-adminer` -> fully templated, only renders for postgres/mysql, in profile dev-tools.
- docker-compose.yml: postgres data volume mounted at /var/lib/postgresql/data is unused by postgres:18 -> mounted at /var/lib/postgresql.
- docker-compose.yml: x-app-environment anchors only passed POSTGRES_* / BROKER_* -> replaced with env_file: .env so all cache/broker variables flow through regardless of choice.
- docker-compose.yml: sqlite-init was in profile [init] but app.depends_on referenced it, breaking compose validation -> profile removed; init logic inlined into the compose command so no script mount is needed.
- docker-compose.yml: kafka used cp-kafka:8.1.0 in Zookeeper mode (requires KAFKA_PROCESS_ROLES) -> switched to KRaft single-node, Zookeeper removed.
- scripts/init-db.sql: CREATE USER/CREATE DATABASE collided with what the postgres image already creates from POSTGRES_USER/POSTGRES_DB -> reduced to idempotent extensions + grants.
- Makefile: hardcoded `antiques:` image tags, `redis` in dev-setup-docker, unconditional Kafka helpers -> templated and gated by cookiecutter choices.
- hooks/post_gen_project.py: tried to locate cookiecutter.json relative to the template (cookiecutter does not expose that) and printed Unicode emoji which crashed on Windows cp1251 consoles -> rewritten to copy the already-rendered env.template to .env. ASCII only.
- config/redis.py: redis_cache_prefix default was "antiques:" -> uses {{cookiecutter.project_slug}}.
- env.template: BROKER_URL for Kafka was kafka://kafka:9092 -> kafka:9092 (the bootstrap-servers form faststream expects). Cache section now uses REDIS_* envvars for all Redis-protocol backends (redis/keydb/dragonfly) and TARANTOOL_* for Tarantool.
- Added .gitattributes forcing LF for *.sh / *.py / Dockerfile / Makefile so shell scripts run inside Linux containers when the template is generated on Windows.

Conditional rendering bugs (compiled code that contradicted the user's choice):
- infrastructures/broker/publisher.py: only had a Kafka implementation regardless of use_broker -> rewritten with Jinja branches for kafka, rabbitmq, nats, and a no-op variant for "none". Single unified class name MessageBrokerPublisher.
- infrastructures/cache/redis_client.py: only had a Redis implementation regardless of use_cache -> rewritten with Jinja branches. CacheClient (with RedisCacheClient backwards-compat alias) implements the Redis-protocol backends (redis/keydb/dragonfly) and a no-op for tarantool/none.
- config/ioc/providers.py: hardcoded `from faststream.kafka import KafkaBroker`, `KafkaPublisher`, and unconditional `redis.asyncio.from_url(...)` even when the user chose a different stack -> imports the right broker type per choice, registers BrokerProvider only when use_broker != "none", and registers a no-op cache when no Redis-protocol backend is selected.
- config/ioc/di.py: unconditional `BrokerProvider()` -> conditional import and registration.
- config/database.py: every field was `Field(..., alias="POSTGRES_*")`, meaning Settings() failed validation for any non-Postgres choice -> all fields default to "" and the canonical URL is read from DATABASE_URL, while engine-specific fields are kept for backwards compat.

Tested by generating and running three combinations:
- postgres + redis + rabbitmq -> /api/docs returned 200
- sqlite + none + none -> /api/docs returned 200
- postgres + redis + kafka (KRaft) -> /api/docs returned 200

## Description

<!-- Provide a brief description of the changes in this pull request -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test improvements
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 🚀 Performance improvement
- [ ] 🔒 Security improvement

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" or "Related to #123" -->

Fixes #
Related to #

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots/Videos

<!-- If applicable, add screenshots or videos to help explain your changes -->

## Additional Notes

<!-- Add any additional information that reviewers should know -->
